### PR TITLE
Adds forked version of spacy-lookup to requirements.txt

### DIFF
--- a/.github/workflows/spoc-app.yml
+++ b/.github/workflows/spoc-app.yml
@@ -28,10 +28,10 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         # See https://flake8.pycqa.org/en/latest/user/options.html
-        flake8 . --count --show-source --statistics --max-line-length=127 --exclude=doc
+        flake8 . --count --show-source --statistics --max-line-length=127 --exclude=doc,spacy-lookup
     - name: Code formatting with black
-      run: black --check src
+      run: black --check src --exclude spacy-lookup
     - name: Type checking with mypy
-      run: mypy src
+      run: mypy src --exclude spacy-lookup
     - name: Test with pytest
       run: pytest test/

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ mypy==0.812
 fastapi==0.63.0
 pytest==6.2.2
 lxml==4.6.2
+-e git+https://github.com/sul-dlss-labs/spacy-lookup.git@57fdf93a01db7aaac6ec4f896f6f7aa60eedeb50#egg=spacy_lookup


### PR DESCRIPTION
Following directions [here](https://www.fir3net.com/Miscellaneous/Programming/how-to-install-a-git-repo-directly-via-pip.html), adds our forked version of [Spacy Lookup](https://github.com/sul-dlss-labs/spacy-lookup) that supports spaCy 3.x. 