### PR TITLE
Continuous deployment to AWS EC2 with github actions

### DIFF
--- a/.github/workflows/spoc-deploy.yml
+++ b/.github/workflows/spoc-deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to AWS EC2
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  AWS_EC2_PRIVATE_KEY: ${{secrets.AWS_EC2_PRIVATE_KEY}}
+  AWS_EC2_HOST: ${{secrets.AWS_EC2_HOST}}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: EC2 Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up private key on runner
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$AWS_EC2_PRIVATE_KEY" > ~/.ssh/private.key
+          chmod 400 ~/.ssh/private.key
+          ssh-keyscan -H $AWS_EC2_HOST > ~/.ssh/known_hosts
+      - name: Login to EC2 server and run deploy script
+        run: |
+          ssh -i ~/.ssh/private.key ubuntu@"$AWS_EC2_HOST" .spoc/deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ WORKDIR /usr/src/app
 
 COPY . .
 
+RUN apt-get update && apt-get install -y git
+
 RUN pip install --no-cache -r requirements.txt
 
 RUN python -m spacy download en_core_web_sm
 
 EXPOSE 8501
 
-CMD streamlit run src/apps/spoc_verifier.py
+CMD streamlit run --server.address 0.0.0.0 src/apps/spoc_verifier.py

--- a/DockerfileAPI
+++ b/DockerfileAPI
@@ -4,8 +4,10 @@ WORKDIR /usr/src/app
 
 COPY . .
 
+RUN apt-get update && apt-get install -y git
+
 RUN pip install --no-cache -r requirements.txt
 
 EXPOSE 8501
 
-CMD uvicorn src.api.main:app
+CMD uvicorn --host 0.0.0.0 src.api.main:app

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Using SPOC repo"
+
+cd spoc
+
+echo "Pull in latest changes from main branch"
+
+git pull origin main
+
+echo "Stop docker-compose"
+
+sudo docker-compose stop
+
+echo "Start up docker-compose to build and run containers"
+
+sudo docker-compose up -d --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  verifier:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8501:8501
+
+  api:
+    build:
+      context: .
+      dockerfile: DockerfileAPI
+    ports:
+      - 8000:8000


### PR DESCRIPTION
Fixes #5 
The AWS EC2 Deploy now fails because it is pulling from `main` which does not have the deploy script. If the CI build is passing, this PR can still be merged. 